### PR TITLE
Remove mlflow package (PS-1442)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN python3 -m pip install --upgrade pip
 RUN pip3 install --use-feature=2020-resolver --no-cache-dir \
-        mlflow \
         pyspark \
         pandas \
         plotly \


### PR DESCRIPTION
Now it should be available only for `python-mlflow` sandboxes.